### PR TITLE
Eerste versie API

### DIFF
--- a/Technische specificatie/20190718 LVBAG-BAG20-BAGAPI-openapi-inprogress.yaml
+++ b/Technische specificatie/20190718 LVBAG-BAG20-BAGAPI-openapi-inprogress.yaml
@@ -1,0 +1,1852 @@
+#----#
+# API Design opmerkingen 
+#----#
+# Behoren niet tot de API maar geven wat informatie over wat keuzes/aandachtspunten tijdens het specificeren  
+
+#--#
+# Openstaande punten 
+#--#
+#TODO: Toevoegen: examples voor elk kenmerk toevoegen volgens OAS3 https://swagger.io/docs/specification/adding-examples/  
+#TODO: Mooier maken: externe yaml files voor ref's - toevoegen aan eigen github (als er VNG staat, of die van KP-API niet voldoen). 
+#TODO: Mooier maken: expand, toevoegen nog aan parameters.yaml bij KP-API of aan eigen. 
+#TODO: Accepteren? OAS3 warning bij sibling entries toe bij een $ref. Mag wel in JSON. Warning toestaan, of is wat anders mogelijk?
+#TODO: headers naar externe sites die niet KP-API en niet Kadaster zijn, vervangen door Kadaster eigen of KP-API. We kunnen hier wachten op KP-API en even die van VNG gebruiken. Tzt wel vervangen: Bv. Foutbericht en expand. 
+
+#--#
+#Ontwerpbeslissingen 
+#--#
+# Indeling in (kleine) API's: een API voor Woonplaats, Openbare ruimte, en Nummeraanduiding. 
+# Geen adresseerbare objecten, maar wel met links naar adresseerbare objecten, vanuit Nummeraanduiding_links. 
+#
+# Bronhouder van een object is geen BAG gegeven en is vaak niet nodig, maar is soms wel erg fijn. 
+# Daarom toegevoegd als optioneel mee te leveren gegeven, via een expand optie, als embedded resource. 
+#
+# Standaard volgen de HAL links beide richtingen van de relaties. 
+# Dus een openbare ruimte heeft een HAL link naar woonplaatsen, en een woonplaats heeft een HAL link naar de openbare ruimtes.
+
+# Standaard volgen de embedded resources de navigatierichting van het informatiemodel. 
+# Dus een openbare ruimte heeft wel een woonplaats_embedded, maar een woonplaats heeft niet de openbare ruimtes embedded. 
+# Embedded resources - naamgeving conventie van de property waarin de embedded resource komt: 
+# naam van de relatie + naam van de resource. Bijvoorbeeld: openbare ruimte met embedded woonplaats wordt: ligtInWoonplaats. 
+# TODO: (generatie) _embedded resources genereren conform ontwerpbeslissingen. 
+
+# Standaard wordt de identificatie van het gerelateerde object opgenomen in het object die de eigenaar is van de relatie. 
+# Dus een openbare ruimte heeft wel een property ligtIn met daarin als data NL.IMBAG.Woonplaats.0123  
+
+# Enumeraties krijgen als standaard naamgeving de postfix _enum. 
+# TODO: (generatie) bij enumeratie "_enum" toevoegen aan de naam, en analoog: _valuelist
+
+# Resource Woonplaats en hoe opnemen in onderzoek informatie? 
+# 1. Resource WoonplaatsIO, de resource Woonplaats met daarin de bijbehorende InOnderzoek informatie als gewone gegevens erbij
+# 2. Resource Woonplaats als aparte resource met In Onderzoek als aparte resource, eventueel embedded of linked. 
+# 3. Zoals 1, maar deze gewoon Woonplaats noemen. 
+# 
+# Gezien elk objecttype kenmerken kent die in onderzoek kunnen zijn en in onderzoek metadata is die inherent hoort bij de resource, graag altijd meeleveren met de resource. Dus #1. een Woonplaats resource met daarin een property InOnderzoek.   
+
+# Voorkomens van objecten, zijn geen aparte resources. 
+# Voorkomen-id ook in path? Nee, moet optioneel zijn, in aanvulling op de object identificatie, dus query parameter.
+# M.b.t. NEN3610 ID's: in /get operaties wordt alleen lokaalID gebruikt. Bv. /woonplaatsen/0518
+# TODO: (UML)Voorkomen als property/component van een object, of als AllOf constructie? 
+
+#Vraag: naamgevingconventie tussen 1 object=1resource, en resource=1object+embeddedobjecten). 
+#Antwoord: een resource wordt altijd benoemd naar wat het is. Dus als het kan, heet het gewoon Woonplaats. Als er embedded resources in worden opgenomen, zoals een openbare ruimte me daarin een woonplaats, dan veranderd de naam van de resource daardoor niet (de embedded kunnen met de expand keuze meegeleverd worden, of worden weggelaten). Let wel, een vraag naar de levenscyclus van een object levert sec de gegevens op zonder embedded/geneste objecten. Dit is dus een andere resource. Levenscyclus vragen kunnen overigens beter in een andere API.
+
+#----#
+
+#Nu volgt de OAS specificatie - voor technische definities, zie https://swagger.io/specification/ 
+openapi: 3.0.0
+
+#Server specificatie 
+servers:
+  - description: Landelijke Voorziening BAG 
+    url: https://api.kadaster.nl/lvbag/bag20/api/v0
+  - description: "Referentie-implementatie"
+    url: https://api.kadaster.nl/lvbag/eto/bag20/api/v0
+    
+#API specificatie - algemeen
+info:
+  title: IMBAG 2.0 API - van de LVBAG 
+  description: >
+    Dit is de BAG API van de landelijke voorziening BAG (LVBAG) voor het informatiemodel IMBAG 2.0 en conform de API strategie 1.1 specificatie in OAS3. Deze is vooral gericht op individuele bevragingen (op basis van de identificerende gegevens van een object). 
+    <br/><br/>
+    <font color='red'>**LET OP: Deze specificatie is een \"work in progress\"**, oftewel niet definitief.</font><br/><br/>
+    Meer informatie over BAG 2.0 is te vinden op: [Catalogus BAG 2.0](https://www.geobasisregistraties.nl/basisregistraties/adressen-en-gebouwen)
+    <br/>
+    Meer informatie over Nederlandse API strategie is te vinden op: [API-Strategie](https://docs.geostandaarden.nl/api/API-Strategie) - deze API volgt versie 1.1 van 20190213. 
+    <br/>
+    Meer informatie over OAS3 specificatie is te vinden op: [OAS](https://www.forumstandaardisatie.nl/standaard/openapi-specification)  
+    <br/>
+    Het standaard mediatype HAL (`application/hal+json`) wordt gebruikt. Dit is een mediatype voor het weergeven van resources en hun relaties via hyperlinks.
+    <br/>
+    <br/>
+    Voor vragen, neem contact op met de BAG beheerder o.v.v. BAG API 2.0. We zijn aan het kijken naar een geschikt medium hiervoor, mede ook om de API iteratief te kunnen opstellen of doorontwikkelen samen met de community. Als de API iets (nog) niet kan, wat u wel graag wilt, neem dan contact op. 
+    <br/>
+    <br/>
+    Een API-key kan  verkregen worden door een e-mail te sturen naar: zie onderstaande contactgegevens <font color='blue'>send e-mail</font>. 
+    
+  version: "0.1" #Deze wordt 1.0 als de API naar productie gaat.
+  termsOfService: https://zakelijk.kadaster.nl/algemene-voorwaarden
+  contact:
+    name: Kadaster - Beheerder Landelijke Voorziening BAG 
+    email: "bag@kadaster.nl"  
+    url: https://zakelijk.kadaster.nl/bag
+  license:
+    name: European Union Public License, version 1.2 (EUPL-1.2)
+    url: https://eupl.eu/1.2/nl/
+
+security:
+  - apiKeyBAG: []
+  # Alle requests verwachten een (BAG) API key (niet per operation of end-point veschillend)
+  # Voor defintie van benoemde 'apiKeyBAG', zie security-schemes onderin. 
+
+#+Functionele toelichting bij de operations/end-points als documentatie indeling. 
+tags:
+  - 
+    name: Algemene informatie
+    description: >-
+      Het endpoint voor algemene  informatie levert informatie op van de API. 
+      
+  - 
+    name: Woonplaats
+    description: >-
+      Dit endpoint levert één of meer (voorkomens van) woonplaats(en), met embedded resources en links. 
+  - 
+    name: Openbare ruimte
+    description: >- 
+      Dit endpoint levert één of meer (voorkomens van) openbare ruimte(en), met embedded resources en links.
+  - 
+    name: Nummeraanduiding
+    description: >-
+      Dit endpoint levert één of meer (voorkomens van) nummeraanduiding(en), met embedded resources en links.
+
+paths:
+
+  /info:
+    get:
+      summary: 'Algemene info van de API'
+      tags:
+        - Algemene informatie
+      operationId: getInfo
+      responses:
+        '200':
+          description: "Bevraging getInfo geslaagd"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/API-info' #Generieke file van maken. 
+        default:
+          description: 'Onverwacht probleem'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+
+  #Vraag woonplaatsIdentificatie
+  /woonplaatsen/{identificatie}:
+    get:
+      tags:
+        - Woonplaats
+      summary: bevragen 1 woonplaats, op basis van de identificatie.  
+      operationId: woonplaatsIdentificatie
+      description: >-
+        Bevragen/raadplegen van één voorkomen van een Woonplaats, via de identificatie van de woonplaats. 
+        Geleverd wordt een woonplaats. 
+        Als geldigOp en/of beschikbaarOp niet wordt opgegeven, worden de actuele gegevens geleverd. 
+        De Crs in de header moet zijn epsg:28992
+      parameters: 
+        - in: path
+          name: identificatie
+          description: "De unieke aanduiding van een woonplaats, zoals opgenomen in de landelijke woonplaatsentabel. De woonplaatsen worden vastgesteld door de gemeenten. De vastgestelde woonplaatsen worden voorzien van een unieke aanduiding, te vergelijken met de gemeentecode volgens Tabel 33 'Gemeententabel' van de Landelijke Tabellen GBA. Deze aanduiding wordt verstrekt door de Dienst voor het kadaster en de openbare registers."
+          required: true
+          schema:
+            type: string
+            maxLength: 4
+          example: 0123  
+          
+          #default        - $ref: '#/components/parameters/apiKey'
+          #default        - $ref: '#/components/parameters/accept'
+        - $ref: "https://cdn.jsdelivr.net/gh/geonovum/kp-api-guidelines@1.0.0/components/parameters.yaml#/acceptCrs"
+          #TODO/overweging: Eigen Accept-CRS maken, voorlopig met alleen RD? 
+        - $ref: '#/components/parameters/geldigOp'
+        - $ref: '#/components/parameters/beschikbaarOp'
+        #nvt - $ref: '#/components/parameters/page'
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/parameters.yaml#/expand"
+        
+      #Antwoord woonplaatsIdentificatie
+      responses:
+        '200':
+          description: "Bevraging woonplaatsIdentificatie geslaagd"
+          headers:
+            api-version: #Is dit wel API strategie?
+              $ref: '#/components/schemas/API-info'
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              # 1 resource, niet een collectie, dus geen items en geen paginering.
+              schema:
+                $ref: '#/components/schemas/WoonplaatsIO'
+                
+        '401':
+            $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/401'
+        '403':
+          $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/403'
+        '404':
+          $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/404'
+        '406':
+          $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/406'
+        '503':
+          $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/503'
+        '500':
+          description: Internal Server Error
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        'default':
+          description: Er is een onverwachte fout opgetreden.
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+                
+  #Vraag woonplaatsen
+  /woonplaatsen:
+    get:
+      tags:
+        - Woonplaats
+      summary: bevragen woonplaatsen, allemaal (met paginering) of op basis van de (exacte) naam. 
+      operationId: woonplaatsen
+      description: >-
+        Bevragen/zoeken van één of meer woonplaatsen, via paginering of via een exacte match op de naam. de exacte naam van de woonplaats (met of zonder diakrieten).
+        Geleverd wordt een woonplaats. 
+        Als geldigOp en/of beschikbaarOp niet wordt opgegeven, worden de actuele gegevens geleverd. 
+        De Crs in de header moet zijn epsg:28992
+      parameters: 
+        - in: query
+          name: naam
+          description: "De benaming van een door het gemeentebestuur aangewezen woonplaats. De benaming van een door het gemeentebestuur aangewezen woonplaats. De benaming van een door het gemeentebestuur aangewezen woonplaats. Het maximale aantal te gebruiken tekens voor een benaming is tachtig. Het verdient aanbeveling te streven naar korte benamingen."
+          required: false
+          schema:
+            type: string
+            maxLength: 80
+            example: "Apeldoorn"
+            
+          #default        - $ref: '#/components/parameters/apiKey'
+          #default        - $ref: '#/components/parameters/accept'
+        - $ref: "https://cdn.jsdelivr.net/gh/geonovum/kp-api-guidelines@1.0.0/components/parameters.yaml#/acceptCrs"
+        - $ref: '#/components/parameters/geldigOp'
+        - $ref: '#/components/parameters/beschikbaarOp'
+        - $ref: 'https://rawgit.com/PDOK/open-api-specs/master/shared/parameters.yaml#/page'
+        - $ref: 'https://rawgit.com/PDOK/open-api-specs/master/shared/parameters.yaml#/pageSize'
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/parameters.yaml#/expand"
+
+      #Antwoord woonplaatsen      
+      responses:
+        '200':
+          description: "Zoekactie woonplaatsen geslaagd"
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+            X-Pagination-Page:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+            X-Pagination-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+              
+                type: object
+                properties:
+                  _embedded:
+                    type: object
+                    properties:
+                      woonplaatsen:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/WoonplaatsIO'
+                  _links:
+                    #Meerdere items, dus paginering op response niveau (niet in de resource).  
+                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
+
+        '400':
+          description: Bad Request
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/ValidatieFoutbericht"
+        '401':
+          description: Unauthorized
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '403':
+          description: Forbidden
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '406':
+          description: Not Acceptable
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '409':
+          description: Conflict
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '410':
+          description: Gone
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '412':
+          description: Precondition Failed
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/api_version"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '415':
+          description: Unsupported Media Type
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '429':
+          description: Too Many Requests
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '500':
+          description: Internal Server Error
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        'default':
+          description: Er is een onverwachte fout opgetreden.
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+
+  #Vraag openbareruimtenIdentificatie
+  /openbare-ruimten/{identificatie}:
+    get:
+      operationId: openbareruimtenIdentificatie
+      tags: 
+        - Openbare ruimte
+      summary: bevragen 1 openbare ruimte op basis van de identificatie. 
+      description: >-
+        Bevragen/raadplegen één openbare ruimte, via de identificatie van een openbare ruimte. 
+        Geleverd wordt de openbare ruimte, met embedded de woonplaats waar de openbare ruimte in ligt. 
+        Als geldigOp en/of beschikbaarOp niet wordt opgegeven, worden de actuele gegevens geleverd. 
+        De Crs in de header moet zijn epsg:28992
+      parameters: 
+        - in: path
+          name: identificatie
+          description: "De unieke aanduiding van een openbare ruimte object."
+          required: true
+          schema:
+            type: string
+            maxLength: 16
+
+          #default        - $ref: '#/components/parameters/apiKey'
+          #default        - $ref: '#/components/parameters/accept'
+        - $ref: "https://cdn.jsdelivr.net/gh/geonovum/kp-api-guidelines@1.0.0/components/parameters.yaml#/acceptCrs"
+        
+        # Tijdreis parameters toegestaan. 
+        - $ref: '#/components/parameters/geldigOp'
+        - $ref: '#/components/parameters/beschikbaarOp'
+        # Expand toegestaan voor woonplaats. 
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/parameters.yaml#/expand" #TODO: Toevoegen nog aan parameters.yaml 
+        # Paginering toegestaan? Nee. 
+        #- $ref: 'https://rawgit.com/PDOK/open-api-specs/master/shared/parameters.yaml#/page'
+        #- $ref: 'https://rawgit.com/PDOK/open-api-specs/master/shared/parameters.yaml#/pageSize'
+      
+      #Antwoord openbareruimtenIdentificatie
+      responses:
+        '200':
+          description: "Bevraging openbareruimtenIdentificatie geslaagd"
+          headers:
+            api-version: #Is dit wel API strategie?
+              $ref: '#/components/schemas/API-info'
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              # 1 resource, niet een collectie, dus geen items en geen paginering.
+              schema:
+                $ref: '#/components/schemas/OpenbareRuimteIO'
+              
+        '401':
+            $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/401'
+        '403':
+          $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/403'
+        '404':
+          $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/404'
+        '406':
+          $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/406'
+        '503':
+          $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/503'
+        '500':
+          description: Internal Server Error
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        'default':
+          description: Er is een onverwachte fout opgetreden.
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+
+  /woonplaats/{identificatie}/openbare-ruimten:
+    get:
+      operationId: woonplaatsIdentificatieOpenbareruimten
+      tags: 
+        - Openbare ruimte
+      summary: zoeken openbare ruimtes, alle in een woonplaats (met paginering)
+      description: >
+       Bevragen/zoeken van één of meer openbare ruimtes, via een exacte match op de identificatie van een woonplaats. 
+        Geleverd wordt de openbare ruimte, met embedded de woonplaats waar de openbare ruimte in ligt. 
+        Als geldigOp en/of beschikbaarOp niet wordt opgegeven, worden de actuele gegevens geleverd. 
+        De Crs in de header moet zijn epsg:28992     
+      parameters: 
+        - in: path
+          name: identificatie
+          description: "De unieke aanduiding van een woonplaats, zoals opgenomen in de landelijke woonplaatsentabel. De woonplaatsen worden vastgesteld door de gemeenten. De vastgestelde woonplaatsen worden voorzien van een unieke aanduiding, te vergelijken met de gemeentecode volgens Tabel 33 'Gemeententabel' van de Landelijke Tabellen GBA. Deze aanduiding wordt verstrekt door de Dienst voor het kadaster en de openbare registers."
+          required: true
+          schema:
+            type: string
+            maxLength: 4
+          example: NL.IMBAG.Woonplaats.0123 of 0123 #UITZOEKEN! 
+          #default        - $ref: '#/components/parameters/apiKey'
+          #default        - $ref: '#/components/parameters/accept'
+        - $ref: "https://cdn.jsdelivr.net/gh/geonovum/kp-api-guidelines@1.0.0/components/parameters.yaml#/acceptCrs"
+        - $ref: '#/components/parameters/geldigOp'
+        - $ref: '#/components/parameters/beschikbaarOp'
+        - $ref: 'https://rawgit.com/PDOK/open-api-specs/master/shared/parameters.yaml#/page'
+        - $ref: 'https://rawgit.com/PDOK/open-api-specs/master/shared/parameters.yaml#/pageSize'
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/parameters.yaml#/expand"
+        
+      responses:
+        '200':
+          description: "Zoekactie woonplaatsIdentificatieOpenbareruimten geslaagd"
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+            X-Pagination-Page:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+            X-Pagination-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                #Vanwege paginering een object met _embedded en met _links voor paginering. 
+                type: object
+                properties:
+                  _embedded:
+                    type: object
+                    properties:
+                      openbareruimten:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/OpenbareRuimteIO'
+                  _links:
+                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
+
+        '400':
+          description: Bad Request
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/ValidatieFoutbericht"
+        '401':
+          description: Unauthorized
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '403':
+          description: Forbidden
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '406':
+          description: Not Acceptable
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '409':
+          description: Conflict
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '410':
+          description: Gone
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '412':
+          description: Precondition Failed
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '415':
+          description: Unsupported Media Type
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '429':
+          description: Too Many Requests
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '500':
+          description: Internal Server Error
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        'default':
+          description: Er is een onverwachte fout opgetreden.
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+
+#Vraag openbareruimtenIdentificatie
+  /nummeraanduidingen/{identificatie}:
+    get:
+      operationId: nummeraanduidingenIdentificatie
+      tags: 
+        - Nummeraanduiding
+      summary: bevragen 1 nummeraanduiding op basis van de identificatie. 
+      description: >-
+        Bevragen/raadplegen één openbare ruimte, via de identificatie van een openbare ruimte. 
+        Geleverd wordt de openbare ruimte, met embedded de woonplaats waar de openbare ruimte in ligt. 
+        Als geldigOp en/of beschikbaarOp niet wordt opgegeven, worden de actuele gegevens geleverd. 
+        De Crs in de header moet zijn epsg:28992
+      parameters: 
+        - in: path
+          name: identificatie
+          description: "De unieke aanduiding van een nummeraanduiding object."
+          required: true
+          schema:
+            type: string
+            maxLength: 16
+
+          #default        - $ref: '#/components/parameters/apiKey'
+          #default        - $ref: '#/components/parameters/accept'
+        - $ref: "https://cdn.jsdelivr.net/gh/geonovum/kp-api-guidelines@1.0.0/components/parameters.yaml#/acceptCrs"
+        
+        # Tijdreis parameters toegestaan. 
+        - $ref: '#/components/parameters/geldigOp'
+        - $ref: '#/components/parameters/beschikbaarOp'
+        # Expand toegestaan voor woonplaats. 
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/parameters.yaml#/expand" 
+        # Paginering toegestaan? Nee. 
+        #- $ref: 'https://rawgit.com/PDOK/open-api-specs/master/shared/parameters.yaml#/page'
+        #- $ref: 'https://rawgit.com/PDOK/open-api-specs/master/shared/parameters.yaml#/pageSize'
+      
+      #Antwoord nummeraanduidingenIdentificatie
+      responses:
+        '200':
+          description: "Bevraging nummeraanduidingenIdentificatie geslaagd"
+          headers:
+            api-version: 
+              $ref: '#/components/schemas/API-info'
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              # 1 resource, niet een collectie, dus geen items en geen paginering.
+              schema:
+                $ref: '#/components/schemas/NummeraanduidingIO'
+              
+        '401':
+            $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/401'
+        '403':
+          $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/403'
+        '404':
+          $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/404'
+        '406':
+          $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/406'
+        '503':
+          $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/responses.yaml#/503'
+        '500':
+          description: Internal Server Error
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        'default':
+          description: Er is een onverwachte fout opgetreden.
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+    
+  /openbare-ruimte/{identificatie}/nummeraanduidingen:
+    get:
+      operationId: OpenbareruimteIdentificatieNummeraanduidingen
+      tags: 
+        - Nummeraanduiding
+      summary: zoeken nummeraanduiding, alle in een openbare ruimte (met paginering)
+      description: >
+       Bevragen/zoeken van één of meer nummeraanduidingen, via een exacte match op de identificatie van een openbare ruimte. 
+        Geleverd wordt de nummeraanduiding, met embedded de openbare ruimte en de woonplaats waar deze in ligt. 
+        Als geldigOp en/of beschikbaarOp niet wordt opgegeven, worden de actuele gegevens geleverd. 
+        De Crs in de header moet zijn epsg:28992     
+      parameters: 
+        - in: path
+          name: identificatie
+          description: "De unieke aanduiding van een openbare ruimte." 
+          required: true
+          schema:
+            type: string
+            maxLength: 16
+          example: 0123100000000001 
+          #default        - $ref: '#/components/parameters/apiKey'
+          #default        - $ref: '#/components/parameters/accept'
+        - $ref: "https://cdn.jsdelivr.net/gh/geonovum/kp-api-guidelines@1.0.0/components/parameters.yaml#/acceptCrs"
+        - $ref: '#/components/parameters/geldigOp'
+        - $ref: '#/components/parameters/beschikbaarOp'
+        - $ref: 'https://rawgit.com/PDOK/open-api-specs/master/shared/parameters.yaml#/page'
+        - $ref: 'https://rawgit.com/PDOK/open-api-specs/master/shared/parameters.yaml#/pageSize'
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/parameters.yaml#/expand"
+        
+      responses:
+        '200':
+          description: "Zoekactie OpenbareruimteIdentificatieNummeraanduidingen geslaagd"
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/warning"
+            X-Pagination-Page:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Page"
+            X-Pagination-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Pagination_Limit"
+            X-Rate-Limit-Limit:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Limit"
+            X-Rate-Limit-Remaining:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Remaining"
+            X-Rate-Limit-Reset:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/headers.yaml#/X_Rate_Limit_Reset"
+          content:
+            application/hal+json:
+              schema:
+                #Vanwege paginering een object met _embedded en met _links voor paginering. 
+                type: object
+                properties:
+                  _embedded:
+                    type: object
+                    properties:
+                      nummeraanduidingen:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/NummeraanduidingIO'
+                  _links:
+                    $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/HalPaginationLinks"
+
+        '400':
+          description: Bad Request
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/ValidatieFoutbericht"
+        '401':
+          description: Unauthorized
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '403':
+          description: Forbidden
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '406':
+          description: Not Acceptable
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '409':
+          description: Conflict
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '410':
+          description: Gone
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '412':
+          description: Precondition Failed
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '415':
+          description: Unsupported Media Type
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '429':
+          description: Too Many Requests
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        '500':
+          description: Internal Server Error
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"
+        'default':
+          description: Er is een onverwachte fout opgetreden.
+          headers:
+            api-version:
+              $ref: '#/components/schemas/API-info'
+          content:
+            application/problem+json:
+              schema:
+                $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/components.yaml#/Foutbericht"    
+                
+components:
+
+  securitySchemes:
+    apiKeyBAG: 
+      type: apiKey
+      name: X-Api-Key
+      in: header
+      description: >
+        De API-key die je hebt gekregen dient bij elke request naar deze
+        via de `X-Api-Key` request header meegestuurd te worden. Indien deze
+        niet juist wordt meegestuurd, of het een ongeldige key betreft, zul je
+        de foutmelding `403 Forbidden` terugkrijgen.
+
+  #Kiezen: alle parameters hier, of alleen de in query, of alleen degene die 2 of meer keer voorkomen? 
+  parameters:
+    #Opsomming van path parameters - /{...} - specificatie bij operation zelf. 
+    identificatie:
+      name: id
+      in: path
+      example: 0123
+      description: Identificatie van een object uit de BAG. Deze is 4 lang bij een woonplaats en 16 lang bij de andere objecten. 
+      required: true
+      schema:
+        type: string
+        maxLength: 16 
+    
+    #Opsomming van request parameters - ?='...' parameters (by name) - specificatie bij operation zelf. 
+    geldigOp:
+      name: geldigOp
+      in: query
+      example: '2019-06-01'
+      required: false
+      description: > 
+        Filtert op objecten die geldig zijn op de opgegeven datum 'YYYY-MM-DDThh:mm:ss.s' 
+        Deze parameters komen uit de API strategie, het hoofdstuk [tijdreizen](https://docs.geostandaarden.nl/api/API-Strategie/#tijdreizen)
+      schema:
+        type: string
+        format: date
+        
+
+    beschikbaarOp:
+      name: beschikbaarOp
+      in: query
+      example: '2019-06-01T12:00:00:000'
+      required: false
+      description: >
+        Filtert op objecten die geldig zijn op de opgegeven datum `YYYY-MM-DDThh:mm:ss.s' 
+        Deze parameters komen uit de API strategie, het hoofdstuk [tijdreizen](https://docs.geostandaarden.nl/api/API-Strategie/#tijdreizen)
+      schema:
+        type: string
+        format: datetime 
+        
+  #Components - schema
+  #  Gebaseerd op json schema behorende bij informatiemodel LVBAGversie 20180601 - generatie specificatie 1.52:
+  #  $schema: 'http://json-schema.org/draft-05/schema#'
+  #  title: IMBAG Afnemers/IMBAGLV/20180601
+  #  Zelf toevoegen: 
+  #     _links:
+  #     Technisch handige notatiewijze in API (als aparte property) 
+  #  JSON schema definitions worden in YAML schema components:        
+
+  schemas:
+  
+    #API-info - algemene informatie voor gebruikers van de API.
+    API-info:
+      type: object 
+      properties:
+        api-name:
+          type: string #Zie bovenin. 
+        api-version:
+          type: string #Zie bovenin. 
+        api-description:
+          type: string #Zie bovenin. 
+        informationmodel:
+          type: string
+          example: IMBAGLV
+        informationmodel-version:
+          type: string #Van het logische informatiemodel die als basis is genomen voor deze API.
+          example: v20190601
+        informationmodel-location:
+          type: string
+          format: URI #Van het logische informatiemodel die als basis is genomen voor deze API. 
+
+    #Informatiemodel - Objecttypen   
+    Woonplaats:
+      title: Woonplaats 
+      description: Een Woonplaats is een door het bevoegde gemeentelijke orgaan als zodanig aangewezen en van een naam voorzien gedeelte van het grondgebied van de gemeente.
+      type: object
+      required:
+        - identificatie
+        - naam
+        - geometrie
+        - status
+        - geconstateerd
+        - documentdatum
+        - documentnummer
+        - voorkomen
+      properties:
+        identificatie:
+          $ref: "#/components/schemas/NEN3610IDWpl"
+        naam:
+          title: naam
+          description: De benaming van een door het gemeentebestuur aangewezen woonplaats.
+          type: string
+          pattern: "^(&#x0020;-&#x007E;&#x00A0;-&#x00FF;&#x0100;-&#x0113;&#x0116;-&#x012B;&#x012E;-&#x014D;&#x0150;-&#x017E;&#x02C7;&#x02D8;-&#x02DB;&#x02DD;&#x2015;&#x2018;-&#x2019;&#x201C;-&#x201D;&#x20AC;&#x2122;&#x2126;&#x215B;-&#x215E;&#x2190;-&#x2193;&#x266A;)$"
+          minLength: 1
+          maxLength: 80
+          example: Apeldoorn
+          
+        geometrie:
+          title: geometrie
+          description: De tweedimensionale geometrische representatie van het vlak dat wordt gevormd door de omtrekken van een woonplaats.
+          $ref: '#/components/schemas/VlakOfMultivlak'
+        status:
+          title: status
+          description: 'De fase van de levenscyclus van een woonplaats, waarin de betreffende woonplaats zich bevindt.'
+          $ref: '#/components/schemas/StatusWoonplaats'
+        geconstateerd:
+          title: geconstateerd
+          description: 'Een aanduiding waarmee kan worden aangegeven dat een woonplaats in de registratie is opgenomen als gevolg van een feitelijke constatering, zonder dat er op het moment van opname sprake was van een regulier brondocument voor deze opname.'
+          $ref: '#/components/schemas/Indicatie'
+        documentdatum:
+          title: documentdatum
+          description: 'De datum waarop het brondocument is vastgesteld, op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een woonplaats heeft plaatsgevonden.'
+          type: string
+          format: date
+          pattern: "^(&#x0020;-&#x007E;&#x00A0;-&#x00FF;&#x0100;-&#x0113;&#x0116;-&#x012B;&#x012E;-&#x014D;&#x0150;-&#x017E;&#x02C7;&#x02D8;-&#x02DB;&#x02DD;&#x2015;&#x2018;-&#x2019;&#x201C;-&#x201D;&#x20AC;&#x2122;&#x2126;&#x215B;-&#x215E;&#x2190;-&#x2193;&#x266A;)$"
+          example: TODO 
+        documentnummer:
+          title: documentnummer
+          description: 'De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een woonplaats heeft plaatsgevonden, binnen een gemeente.'
+          type: string
+          minLength: 1
+          maxLength: 40
+          example: TODO
+        voorkomen:
+          title: voorkomen
+          $ref: '#/components/schemas/Voorkomen'
+        _links:  
+          $ref: "#/components/schemas/Woonplaats_links" 
+
+    WoonplaatsIO:
+      title: Woonplaats in onderzoek #+
+      description: Woonplaats, aangevuld met een limitatieve opsomming van alle kenmerken van dit object die in onderzoek zijn(als metadata). Bij een normale vraag wordt aangegeven welke kenmerken en op dit moment in onderzoek zijn. Bij een tijdreisvraag wordt aangegeven welke gegevens er ooit in onderzoek zijn geweest. Bij een levenscyclus vraag wordt aangegeven welke gegevens er ooit in onderzoek zijn geweest. 
+      type: object
+      required: #+ VNG tussen "" bv. "status"
+        - woonplaats
+      properties:
+        woonplaats:
+          $ref: '#/components/schemas/Woonplaats'
+        inonderzoek:
+          $ref: '#/components/schemas/KenmerkWoonplaatsInOnderzoek'
+          #Gerelateerd objecten als embedded resource. Deze embedded resource is met expand=woonplaatsen op te vragen.  
+        _embedded:
+          type: object 
+          properties: 
+            bronhouder: 
+              $ref: '#/components/schemas/BronhouderInfo'
+
+    NEN3610IDWpl:
+      type: "object"
+      description: "De identificatie van een voorkomen van een woonplaats object, conform de NEN3610 standaard." 
+      required:
+      - "lokaalID"
+      - "namespace"
+      - "versie"
+      properties:
+        lokaalID:
+          type: "string"
+          title: "lokaalID"
+          description: "[0-9]{4}"
+          pattern: "^[0-9]{4}$"
+        namespace:
+          type: "string"
+          title: "namespace"
+          description: "NL.IMBAG.Woonplaats"
+          minLength: 1
+        versie:
+          type: "string"
+          title: "versie"
+          description: ""
+    
+    OpenbareRuimte:
+      title: Openbare ruimte
+      description: Een Openbare ruimte is een door het bevoegde gemeentelijke orgaan als zodanig aangewezen en van een naam voorziene buitenruimte die binnen Ã©Ã©n woonplaats is gelegen.
+      type: object
+      required:
+        - identificatie
+        - naam
+        - type
+        - status
+        - geconstateerd
+        - documentdatum
+        - documentnummer
+        - verkorteNaam
+        - voorkomen
+        - ligtIn
+      properties:
+        identificatie:
+          title: identificatie
+          description: De unieke aanduiding van een openbare ruimte.
+          type: string
+          pattern: '[0-9]{4}[10][0-9]{10}'
+          example: 0518100000000001
+        naam:
+          title: naam
+          description: Een naam die aan een openbare ruimte is toegekend in een daartoe strekkend formeel gemeentelijk besluit.
+          type: string
+          minLength: 1
+          maxLength: 80
+          example: "Laan van Westenenk 701" 
+        type:
+          title: type
+          description: De aard van de als zodanig benoemde openbare ruimte.
+          $ref: '#/components/schemas/TypeOpenbareRuimte'
+        status:
+          title: status
+          description: 'De fase van de levenscyclus van een openbare ruimte, waarin de betreffende openbare ruimte zich bevindt.'
+          $ref: '#/components/schemas/StatusNaamgeving'
+        geconstateerd:
+          title: geconstateerd
+          description: 'Een aanduiding waarmee kan worden aangegeven dat een openbare ruimte in de registratie is opgenomen als gevolg van een feitelijke constatering, zonder dat er op het moment van opname sprake was van een regulier brondocument voor deze opname.'
+          $ref: '#/components/schemas/Indicatie'
+        documentdatum:
+          title: documentdatum
+          description: 'De datum waarop het brondocument is vastgesteld, op basis waarvan een opname, mutatie of verwijdering van gegevens ten aanzien van een openbare ruimte heeft plaatsgevonden.'
+          type: string
+          format: date
+        documentnummer:
+          title: documentnummer
+          description: 'De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een openbare ruimte heeft plaatsgevonden, binnen een gemeente.'
+          type: string
+          minLength: 1
+          maxLength: 40
+        verkorteNaam:
+          title: verkorte naam
+          $ref: '#/components/schemas/VerkorteNaamOpenbareRuimte'
+
+        voorkomen:
+          title: voorkomen
+          $ref: '#/components/schemas/Voorkomen'
+        
+        #Gerelateerd object (eigenaar van het kenmerk c.q. de relatie bevat de identificatie van het gerelateerde object)  
+        ligtIn:
+          title: ligt in
+          description: Een openbare ruimte ligt in een woonplaats.
+          $ref: "#/components/schemas/NEN3610IDWpl"
+
+        #Gerelateerd objecten als embedded resource. Deze embedded resource is met expand=woonplaatsen op te vragen.  
+        _embedded:
+          type: object 
+          properties: 
+            ligtInWoonplaats: 
+              type: array 
+              items: 
+                $ref: '#/components/schemas/WoonplaatsIO'
+
+        #Gerelateerde objecten in de vorm van Links.
+        _links:  
+          $ref: "#/components/schemas/OpenbareRuimte_links"
+
+    NEN3610IDOpr:
+      type: "object"
+      description: "De identificatie van een voorkomen van een openbare ruimte object, conform de NEN3610 standaard." 
+      required:
+      - "lokaalID"
+      - "namespace"
+      - versie
+      properties:
+        lokaalID:
+          type: "string"
+          title: "lokaalID"
+          description: ""
+          pattern: "^[0-9]{16}$"
+        namespace:
+          type: "string"
+          title: "namespace"
+          description: "NL.IMBAG.Openbareruimte"
+          minLength: 1
+        versie:
+          type: "string"
+          title: "versie"
+          description: ""
+          
+    OpenbareRuimteIO:
+      title: Openbare ruimte in onderzoek #+
+      description: Openbare ruimte, aangevuld met een limitatieve opsomming van alle kenmerken van dit object die in onderzoek zijn(als metadata). Bij een normale vraag wordt aangegeven welke kenmerken en op dit moment in onderzoek zijn. Bij een tijdreisvraag wordt aangegeven welke gegevens er ooit in onderzoek zijn geweest. Bij een levenscyclus vraag wordt aangegeven welke gegevens er ooit in onderzoek zijn geweest. 
+      type: object
+      required: #+ VNG tussen "" bv. "status"
+        - openbareruimte
+      properties:
+        openbareruimte:
+          $ref: '#/components/schemas/OpenbareRuimte'
+        inonderzoek:
+          $ref: '#/components/schemas/KenmerkOpenbareruimteInOnderzoek'
+
+    Nummeraanduiding:
+      title: Nummeraanduiding
+      description: 'Een Nummeraanduiding is een door het bevoegde gemeentelijke orgaan als zodanig toegekende aanduiding van een verblijfsobject, een standplaats of een ligplaats.'
+      type: object
+      required:
+        - identificatie
+        - huisnummer
+        - typeAdresseerbaarObject
+        - status
+        - geconstateerd
+        - documentdatum
+        - voorkomen
+        - documentnummer
+        - ligtAan
+      properties:
+        identificatie:
+          title: identificatie
+          description: De unieke aanduiding van een nummeraanduiding.
+          type: string
+          maxLength: 16
+          pattern: '[0-9]{4}[20][0-9]{10}'
+        huisnummer:
+          title: huisnummer
+          description: Een door of namens het gemeentebestuur ten aanzien van een adresseerbaar object toegekende nummering.
+          type: integer
+          minLength: 1
+          maxLength: 5
+          pattern: '[1-9][0-9]{0,4}'
+        huisletter:
+          title: huisletter
+          description: Een door of namens het gemeentebestuur ten aanzien van een adresseerbaar object toegekende toevoeging aan een huisnummer in de vorm van een alfanumeriek teken.
+          type: string
+          maxLength: 1
+          pattern: '[a-zA-Z]{1}'
+        huisnummertoevoeging:
+          title: huisnummertoevoeging
+          description: Een door of namens het gemeentebestuur ten aanzien van een adresseerbaar object toegekende nadere toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter.
+          type: string
+          minLength: 1
+          maxLength: 4
+          pattern: '[0-9a-zA-Z]{1,4}'
+        postcode:
+          title: postcode
+          description: 'De door PostNL vastgestelde code behorende bij een bepaalde combinatie van een straatnaam en een huisnummer.'
+          type: string
+          maxLength: 6
+          pattern: '[1-9][0-9]{3}[A-Z]{2}'
+        typeAdresseerbaarObject:
+          title: type adresseerbaar object
+          description: De aard van het object waaraan een nummeraanduiding is toegekend.
+          $ref: '#/components/schemas/TypeAdresseerbaarObject'
+        status:
+          title: status
+          description: 'De fase van de levenscyclus van een nummeraanduiding, waarin de betreffende nummeraanduiding zich vindt.'
+          $ref: '#/components/schemas/StatusNaamgeving'
+        geconstateerd:
+          title: geconstateerd
+          description: 'Een aanduiding waarmee kan worden aangegeven dat een nummeraanduiding in de registratie is opgenomen als gevolg van een feitelijke constatering, zonder dat er op het moment van opname sprake was van een regulier brondocument voor deze opname.'
+          $ref: '#/components/schemas/Indicatie'
+        documentdatum:
+          title: documentdatum
+          description: 'De datum waarop het brondocument is vastgesteld, op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een nummeraanduiding heeft plaatsgevonden.'
+          type: string
+          format: date
+        voorkomen:
+          title: voorkomen
+          $ref: '#/components/schemas/Voorkomen'
+        documentnummer:
+          title: documentnummer
+          description: 'De unieke aanduiding van het brondocument op basis waarvan een opname, mutatie of een verwijdering van gegevens ten aanzien van een nummeraanduiding heeft plaatsgevonden, binnen een gemeente.'
+          type: string
+          minLength: 1
+          maxLength: 40
+        ligtIn:
+          title: ligt in
+          description: Een nummeraanduiding ligt in een woonplaats.
+          type: array
+          items:
+            $ref: '#/components/schemas/NEN3610IDWpl'
+          minItems: 0
+        ligtAan:
+          title: ligt aan
+          description: Een nummeraanduiding ligt aan een openbare ruimte.
+          items:
+            $ref: '#/components/schemas/NEN3610IDOpr'
+
+        #Gerelateerd objecten als embedded resource. Deze embedded resource is met expand=woonplaatsen op te vragen.  
+        _embedded:
+          type: object 
+          properties: 
+            ligtInWoonplaats: 
+              type: array 
+              items: 
+                $ref: '#/components/schemas/WoonplaatsIO'
+            ligtaanOpenbareRuimte: 
+              type: array 
+              items: 
+                $ref: '#/components/schemas/OpenbareRuimteIO'
+
+        #Gerelateerde objecten in de vorm van Links.
+        _links:  
+          $ref: "#/components/schemas/Nummeraanduiding_links"
+
+    NummeraanduidingIO:
+      title: Nummeraanduiding in onderzoek
+      description: Nummeraanduiding, aangevuld met een limitatieve opsomming van alle kenmerken van dit object die in onderzoek zijn (als metadata). Bij een normale vraag wordt aangegeven welke kenmerken en op dit moment in onderzoek zijn. Bij een tijdreisvraag wordt aangegeven welke gegevens er ooit in onderzoek zijn geweest. Bij een levenscyclus vraag wordt aangegeven welke gegevens er ooit in onderzoek zijn geweest. 
+      type: object
+      required:
+        - openbareruimte
+      properties:
+        nummeraanduiding:
+          $ref: '#/components/schemas/Nummeraanduiding'
+        inonderzoek:
+          $ref: '#/components/schemas/KenmerkNummeraanduidingInOnderzoek'
+
+    #Informatiemodel - Datatypen 
+    StatusWoonplaats:
+      title: StatusWoonplaats
+      description: Een aanduiding van alle waarden die de status van een woonplaats kan aannemen.
+      type: string
+      enum: 
+        - Woonplaats aangewezen
+        - Woonplaats ingetrokken
+        
+    StatusNaamgeving:
+      title: StatusNaamgeving
+      description: Een aanduiding van alle waarden die de status van een openbare ruimte of een nummeraanduiding kan aannemen.
+      type: string
+      enum: 
+        - Naamgeving uitgegeven
+        - Naamgeving ingetrokken
+    
+    TypeOpenbareRuimte:
+      title: TypeOpenbareRuimte
+      description: Een codering van de verschillende waarden die de typering van een openbare ruimte kan aannemen.
+      type: string
+      enum: 
+        - Weg
+        - Water
+        - Spoorbaan
+        - Terrein
+        - Kunstwerk
+        - Landschappelijk gebied
+        - Administratief gebied
+    
+    TypeAdresseerbaarObject:
+      title: TypeAdresseerbaarObject
+      description: De aard van een als zodanig benoemde Nummeraanduiding.
+      type: string
+      enum:
+        - Verblijfsobject
+        - Standplaats
+        - Ligplaats
+        
+    Indicatie:
+      title: Indicatie
+      description: Een aanduiding waarmee wordt aangegeven of een bepaaldenindicatie al dan niet van toepassing is op een erschijningsvorm van een object in de registratie.
+      type: string
+      enum:
+        - J
+        - N
+         
+    KenmerkWoonplaatsInOnderzoek:
+      title: KenmerkWoonplaatsInOnderzoek
+      description: Limitatieve opsomming van alle kenmerken van dit object die in onderzoek zijn op dit moment, of van alle kenmerken die ooit in onderzoek zijn geweest als er een tijdreisvraag is gesteld of een vraag naar de levenscyclus.  
+      type: object
+      required:
+        - kenmerk
+        - identificatieVanLigplaats
+        - inOnderzoek
+        - historie
+        - documentdatum
+        - documentnummer
+      properties:
+        kenmerk:
+          title: kenmerk
+          $ref: '#/components/schemas/InOnderzoekWoonplaats'
+        identificatieVanLigplaats:
+          title: identificatieVanLigplaats
+          type: string
+        inOnderzoek:
+          title: inOnderzoek
+          $ref: '#/components/schemas/Indicatie'
+        historie:
+          title: historie
+          $ref: '#/components/schemas/HistorieInOnderzoek'
+        documentdatum:
+          title: documentdatum
+          type: string
+          format: date
+        documentnummer:
+          title: documentnummer
+          type: string
+          minLength: 1
+          maxLength: 40
+          pattern: \S.*
+          
+    KenmerkOpenbareruimteInOnderzoek:
+      title: KenmerkOpenbareruimteInOnderzoek
+      type: object
+      required:
+        - kenmerk
+        - identificatieVanLigplaats
+        - inOnderzoek
+        - historie
+        - documentdatum
+        - documentnummer
+      properties:
+        kenmerk:
+          title: kenmerk
+          $ref: '#/components/schemas/InOnderzoekOpenbareRuimte'
+        identificatieVanLigplaats:
+          title: identificatieVanLigplaats
+          type: string
+        inOnderzoek:
+          title: inOnderzoek
+          $ref: '#/components/schemas/Indicatie'
+        historie:
+          title: historie
+          $ref: '#/components/schemas/HistorieInOnderzoek'
+        documentdatum:
+          title: documentdatum
+          type: string
+          format: date
+        documentnummer:
+          title: documentnummer
+          type: string
+          minLength: 1
+          maxLength: 40
+          pattern: \S.*
+
+    KenmerkNummeraanduidingInOnderzoek:
+      title: KenmerkNummeraanduidingInOnderzoek
+      type: object
+      required:
+        - kenmerk
+        - identificatieVanLigplaats
+        - inOnderzoek
+        - historie
+        - documentdatum
+        - documentnummer
+      properties:
+        kenmerk:
+          title: kenmerk
+          $ref: '#/components/schemas/InOnderzoekNummeraanduiding'
+        identificatieVanLigplaats:
+          title: identificatieVanLigplaats
+          type: string
+        inOnderzoek:
+          title: inOnderzoek
+          $ref: '#/components/schemas/Indicatie'
+        historie:
+          title: historie
+          $ref: '#/components/schemas/HistorieInOnderzoek'
+        documentdatum:
+          title: documentdatum
+          type: string
+          format: date
+        documentnummer:
+          title: documentnummer
+          type: string
+          minLength: 1
+          maxLength: 40
+          pattern: \S.*
+    
+    InOnderzoekWoonplaats:
+      title: InOnderzoekWoonplaats
+      type: array
+      items:
+        type: string 
+        enum: 
+        - naam
+        - geometrie
+        - status
+    
+    InOnderzoekOpenbareRuimte:
+      title: InOnderzoekOpenbareRuimte
+      type: array
+      items:
+        type: string 
+        enum: 
+        - naam
+        - type
+        - status
+        - gerelateerde woonplaats
+
+    InOnderzoekNummeraanduiding:
+      title: InOnderzoekNummeraanduiding
+      type: array
+      items:
+        type: string 
+        enum:
+        - huisnummer
+        - huisletter
+        - huisnummertoevoeging
+        - postcode
+        - type adresseerbaar object
+        - status
+        - gerelateerde woonplaats
+        - gerelateerde openbare ruimte
+    
+    AN:
+      title: AN
+      type: string
+      
+    Voorkomen:
+      title: Voorkomen
+      type: object
+      required:
+        - tijdstipRegistratie
+        - voorkomenidentificatie
+        - beginGeldigheid
+      properties:
+        tijdstipRegistratie:
+          title: tijdstipRegistratie
+          type: string
+          format: datetime
+        voorkomenidentificatie:
+          title: voorkomenidentificatie
+          type: integer
+        eindRegistratie:
+          title: eindRegistratie
+          type: string
+          format: datetime
+        beginGeldigheid:
+          title: beginGeldigheid
+          type: string
+          format: date
+        eindGeldigheid:
+          title: eindGeldigheid
+          type: string
+          format: date
+        tijdstipInactief:
+          title: tijdstipInactief
+          type: string
+          format: datetime
+          
+    HistorieInOnderzoek:
+      title: HistorieInOnderzoek
+      type: object
+      required:
+        - tijdstipRegistratie
+        - beginGeldigheid
+      properties:
+        tijdstipRegistratie:
+          title: tijdstipRegistratie
+          type: string
+          format: datetime
+        eindRegistratie:
+          title: eindRegistratie
+          type: string
+          format: datetime
+        beginGeldigheid:
+          title: beginGeldigheid
+          type: string
+          format: datetime
+        eindGeldigheid:
+          title: eindGeldigheid
+          type: string
+          format: datetime
+          
+    VerkorteNaamOpenbareRuimte:
+      title: VerkorteNaamOpenbareRuimte
+      type: object
+      required:
+        - verkorteNaam
+      properties:
+        verkorteNaam:
+          title: verkorteNaam
+          type: string
+          minLength: 1
+          maxLength: 24
+
+    BronhouderInfo:
+      title: BronhouderInfo
+      type: object
+      required:
+        - gemeentecode
+      properties:
+        code:
+          title: gemeentecode
+          description: Een officiele code die aan een gemeente is toegekend, ontleend is aan tabel 33 en zoals bijgehouden in de LVBAG. Dit gegeven is geen officieel BAG gegeven en wordt niet als kenmerk van het BAG object Woonplaats object bijgehouden. Het wordt als hulpgegven meegeleverd.
+          type: string
+          pattern: "^[0-9]{4}$" #4 cijfers, met voorloopnullen. 
+          minLength: 4 
+          maxLength: 4
+          example: "0518"
+        naam:         
+          title: naam
+          description: Een officiele naam die aan een gemeente is toegekend. 
+          type: string
+          minLength: 1
+          maxLength: 80
+          example: "Gemeente Apeldoorn" 
+
+    VlakOfMultivlak:
+      title: VlakOfMultivlak
+      oneOf:
+        - $ref: '#/components/schemas/Surface'
+        - $ref: '#/components/schemas/MultiSurface'
+        
+    #Algemene types zoals Geometrie 
+    GeoJsonGeometry:
+      title: 'GeoJSON Geometry'
+      description: 'Geometrie in GeoJSON formaat (RFC 7946).'
+      externalDocs:
+        description: 'RFC 7946 - The GeoJSON Format'
+        url: 'https://tools.ietf.org/html/rfc7946'
+      oneOf:
+        -
+          $ref: '#/components/schemas/Point'
+        -
+          $ref: '#/components/schemas/MultiPoint'
+        -
+          $ref: '#/components/schemas/Polygon'
+        -
+          $ref: '#/components/schemas/Surface'
+        -
+          $ref: '#/components/schemas/MultiPolygon'
+        -
+          $ref: '#/components/schemas/MultiSurface'
+        -
+          $ref: '#/components/schemas/MultiLineString'
+        -
+          $ref: '#/components/schemas/LineString'
+    Point:
+      title: 'GeoJSON Point'
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - Point
+        coordinates:
+          type: array
+          minItems: 2
+          items:
+            type: number
+        bbox:
+          type: array
+          minItems: 4
+          items:
+            type: number
+    MultiPoint:
+      title: 'GeoJSON MultiPoint'
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPoint
+        coordinates:
+          type: array
+          items:
+            type: array
+            minItems: 2
+            items:
+              type: number
+        bbox:
+          type: array
+          minItems: 4
+          items:
+            type: number
+    Surface:
+      $ref: '#/components/schemas/Polygon'
+    Polygon:
+      title: 'GeoJSON Polygon'
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - Polygon
+        coordinates:
+          type: array
+          items:
+            type: array
+            minItems: 4
+            items:
+              type: array
+              minItems: 2
+              items:
+                type: number
+        bbox:
+          type: array
+          minItems: 4
+          items:
+            type: number
+    MultiSurface:
+      $ref: '#/components/schemas/MultiPolygon'
+    MultiPolygon:
+      title: 'GeoJSON MultiPolygon'
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPolygon
+        coordinates:
+          type: array
+          items:
+            type: array
+            items:
+              type: array
+              minItems: 4
+              items:
+                type: array
+                minItems: 2
+                items:
+                  type: number
+        bbox:
+          type: array
+          minItems: 4
+          items:
+            type: number
+    Curve:
+      $ref: '#/components/schemas/LineString'
+    LineString:
+      title: 'GeoJSON LineString'
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - LineString
+        coordinates:
+          type: array
+          minItems: 2
+          items:
+            type: array
+            minItems: 2
+            items:
+              type: number
+        bbox:
+          type: array
+          minItems: 4
+          items:
+            type: number
+    MultiLineString:
+      title: 'GeoJSON MultiLineString'
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiLineString
+        coordinates:
+          type: array
+          items:
+            type: array
+            minItems: 2
+            items:
+              type: array
+              minItems: 2
+              items:
+                type: number
+        bbox:
+          type: array
+          minItems: 4
+          items:
+            type: number
+
+    #TOEVOEGEN LINKS AAN COMPONENTS
+
+    #_links: hier moet nog naar gekeken worden
+    #- $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/schemas.yaml#/HalLink'
+    #- $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/schemas.yaml#/HalCollectionLinks'
+
+    HalLink:
+      description: 'HAL link.'
+      type: object
+      required:
+        - href
+      properties:
+        href:
+          type: string
+    
+    Woonplaats_links:
+    #Geen paginering links hier opnemen, die horen op het niveau van de expand parameter.
+      required:
+        - self
+      type: "object"
+      properties:
+        self:
+          $ref: '#/components/schemas/HalLink'
+        #De standaard relatie richting is van openbare ruimte naar woonplaats. Voor andersom is een hulp link nodig. 
+        openbareruimten:
+          title: "bevat" #Naamgeving, is geen term voor gedefinieerd in het informatiemodel. Dit is in feite ook een relatie service, ingebakken in de Woonplaats_links. Kan/moet ook nog los? Zo nee, omdat deze voldoet, vervalt de relatieservice (mits we dze andersom richting overal op deze manier doen).     
+          type: "object"
+          description: "De gerelateerde openbare ruimtes die in de woonplaats liggen. Van elk gerelateerde openbare ruimte object: hiervan het voorkomen van woonplaats die gevonden wordt op basis van dezelfde tijdreisparameters als waarmee het woonplaats voorkomen gevonden is."
+          properties: 
+            href: 
+              $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/schemas.yaml#/HalLink'
+              
+    OpenbareRuimte_links:
+      type: "object"
+      properties:
+        self:
+          $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/schemas.yaml#/HalLink'
+        woonplaatsen:
+          title: "ligt in"
+          type: "object"
+          description: "De gerelateerde woonplaats. 1 voorkomen van een openbare ruimte ligt altijd in 1 woonplaats."
+          properties: 
+            href: 
+              $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/schemas.yaml#/HalLink'
+        nummeraanduidingen:
+          title: "bevat" #Naamgeving, is geen term voor gedefinieerd in het informatiemodel. Dit is in feite ook een relatie service, ingebakken in de Woonplaats_links. Kan/moet ook nog los? Zo nee, omdat deze voldoet, vervalt de relatieservice (mits we dze andersom richting overal op deze manier doen).     
+          type: "object"
+          description: "De gerelateerde nummeraanduidingen die in de openbare ruimte liggen. Van elk gerelateerde nummeraanduiding object: hiervan het voorkomen van woonplaats die gevonden wordt op basis van dezelfde tijdreisparameters als waarmee het openbare ruimte voorkomen gevonden is."
+          properties: 
+            href: 
+              $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/schemas.yaml#/HalLink'
+
+    Nummeraanduiding_links:
+      type: "object"
+      properties:
+        self:
+          $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/schemas.yaml#/HalLink'
+        woonplaatsen:
+          title: "ligt in"
+          type: "object"
+          description: "De gerelateerde woonplaats. 1 voorkomen van een openbare ruimte ligt altijd in 1 woonplaats."
+          properties: 
+            href: 
+              $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/schemas.yaml#/HalLink'
+
+        openbare-ruimten:
+          title: "bevat" #Naamgeving, is geen term voor gedefinieerd in het informatiemodel. Dit is in feite ook een relatie service, ingebakken in de Woonplaats_links. Kan/moet ook nog los? Zo nee, omdat deze voldoet, vervalt de relatieservice (mits we dze andersom richting overal op deze manier doen).     
+          type: "object"
+          description: "De gerelateerde nummeraanduidingen die in de openbare ruimte liggen. Van elk gerelateerde nummeraanduiding object: hiervan het voorkomen van woonplaats die gevonden wordt op basis van dezelfde tijdreisparameters als waarmee het openbare ruimte voorkomen gevonden is."
+          properties: 
+            href: 
+              $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/schemas.yaml#/HalLink'
+          
+        is-hoofdadres-van:
+          title: "is hoofdadres van"     
+          type: "object"
+          description: "Het gerelateerde adresseerbare object die deze nummeraanduiding als hoofdadres heeft (altijd 1). Van dit gerelateerd adresseerbaar object: hiervan het voorkomen van adresseerbaar object die gevonden wordt op basis van dezelfde tijdreisparameters als waarmee het nummeraanduiding voorkomen gevonden is."
+          properties: 
+            href: 
+              $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/schemas.yaml#/HalLink'
+              #TODO: Nummeraanduidingen toevoegen als resource. 
+
+        is-nevenadres-van:
+          title: "is nevenadres van"     
+          type: "object"
+          description: "Het gerelateerde adresseerbare object die deze nummeraanduiding als nevenadres heeft (altijd 1). Van dit gerelateerd adresseerbaar object: hiervan het voorkomen van adresseerbaar object die gevonden wordt op basis van dezelfde tijdreisparameters als waarmee het nummeraanduiding voorkomen gevonden is."
+          properties: 
+            href: 
+              $ref: 'https://rawgit.com/dvh/KP-APIs/master/oas-components/schemas.yaml#/HalLink'
+
+      


### PR DESCRIPTION
De meegezonden versie bevat de producten:
• wpl, opr+wpl, opr+num+wpl via een bevraging via id
• relatieservices wpl->opr en opr->num
• objecten worden altijd geleverd met IO (optioneel, alleen als relevant)

Bevat niet:
• levenscyclus (andere API)
• gebouwen (andere API)
• platgeslagen adres (vermoedelijk wel in deze API)
• De bronhouder wordt bij alle producten standaard niet geleverd, tenzij aangegeven met
expand=bronhouder. (Deze performt slechter bij panden zonder VBO’s.)