### PR TITLE
Invalid params

### DIFF
--- a/Features/foutafhandeling.feature
+++ b/Features/foutafhandeling.feature
@@ -49,8 +49,7 @@ Bij valideren van een parameter tegen schema kunnen de volgende meldingen komen:
 | minimum          | Waarde is lager dan minimum {minimum}.                    | minimum      |
 | maximum          | Waarde is hoger dan maximum {maximum}.                    | maximum      |
 | minLength        | Waarde is korter dan minimale lengte {minLength}.         | minLength    |
-| maxLength        | Waarde is langer dan maximale lengte {minLength}.         | maxLength    |
-| bereik           | Lengte van waarde moet tussen {minimum} en {maximum} zijn.| size         |
+| maxLength        | Waarde is langer dan maximale lengte {maxLength}.         | maxLength    |
 | pattern          | Waarde voldoet niet aan patroon {pattern}.                | pattern      |
 | enumeratiewaarde | Waarde heeft geen geldige waarde uit de enumeratie.       | enum         |
 | tabelwaarde      | Waarde komt niet voor in de tabel.                        | table        |

--- a/Features/foutafhandeling.feature
+++ b/Features/foutafhandeling.feature
@@ -45,10 +45,12 @@ Bij valideren van een parameter tegen schema kunnen de volgende meldingen komen:
 | type: number     | Waarde is geen geldige number.                            | number       |
 | type: boolean    | Waarde is geen geldige boolean.                           | boolean      |
 | format: date     | Waarde is geen geldige datum.                             | date         |
+| format: timestamp| Waarde is geen geldig tijdstip.                           | timestamp    |
 | minimum          | Waarde is lager dan minimum {minimum}.                    | minimum      |
 | maximum          | Waarde is hoger dan maximum {maximum}.                    | maximum      |
 | minLength        | Waarde is korter dan minimale lengte {minLength}.         | minLength    |
 | maxLength        | Waarde is langer dan maximale lengte {minLength}.         | maxLength    |
+| bereik           | Lengte van waarde moet tussen {minimum} en {maximum} zijn.| size         |
 | pattern          | Waarde voldoet niet aan patroon {pattern}.                | pattern      |
 | enumeratiewaarde | Waarde heeft geen geldige waarde uit de enumeratie.       | enum         |
 | tabelwaarde      | Waarde komt niet voor in de tabel.                        | table        |
@@ -93,8 +95,8 @@ Abstract Scenario: Ongeldige queryparameter waarde bij zoeken
     | code         | reason                                                       | resource             | parameter                  | waarde                      |
     | integer      | Waarde is geen geldige integer.                              | panden               | identificatie              | a                           |
     | number       | Waarde is geen geldige number.                               | panden               | coordinates                | [null, 474479.898]          |
-    | date         | Waarde is geen geldige datum.                                | panden               | beginGeldigheid            | 23-04-2019                  |
-    | date         | Waarde is geen geldige datum.                                | panden               | beginGeldigheid            | 1983-05-00                  |
+    | date         | Waarde is geen geldige datum.                                | panden               | geldigOp                   | 23-04-2019                  |
+    | date         | Waarde is geen geldige datum.                                | panden               | geldigOp                   | 1983-05-00                  |
     | maximum      | Waarde is hoger dan maximum 99999.                           | nummeraanduidingen   | huisnummer                 | 123456                      |
     | maxLength    | Waarde is langer dan maximale lengte 4.                      | nummeraanduidingen   | huisnummertoevoeging       | tegenover                   |
     | pattern      | Waarde voldoet niet aan patroon ^[1-9]{1}[0-9]{3}[A-Z]{2}.   | nummeraanduidingen   | postcode                   | 123aa                       |

--- a/Features/foutafhandeling.feature
+++ b/Features/foutafhandeling.feature
@@ -55,8 +55,6 @@ Bij valideren van een parameter tegen schema kunnen de volgende meldingen komen:
 | enumeratiewaarde | Waarde heeft geen geldige waarde uit de enumeratie.       | enum         |
 | tabelwaarde      | Waarde komt niet voor in de tabel.                        | table        |
 | required         | Parameter is verplicht.                                   | required     |
-| parameters       | Parameter is niet verwacht.                               | unknownParam |
-| fields           | Deel van de parameterwaarde niet correct: {waarde}.       | fields       |
 | expand           | Deel van de parameterwaarde niet correct: {waarde}.       | expand       |
 | wildcard         | Incorrect gebruik van wildcard karakter {wildcard}.       | wildcard     |
 
@@ -77,7 +75,6 @@ Abstract Scenario: Ongeldige pathparameter waarde bij raadplegen resource
     | code         | reason                                                     | resource        | parameter           | waarde                  |
     | minLength    | Waarde is korter dan minimale lengte 16.                   | panden          | pandidentificatie   | 100010921152            |
     | maxLength    | Waarde is langer dan maximale lengte 16.                   | panden          | pandidentificatie   | 980014100010921152      |
-    | unknownParam | Parameter is niet verwacht.                                | panden          | bestaatniet         | fout                    |
     | expand       | Deel van de parameterwaarde is niet correct: bestaatniet.  | panden          | expand              | bestaatniet             |
 
 Abstract Scenario: Ongeldige queryparameter waarde bij zoeken
@@ -101,7 +98,6 @@ Abstract Scenario: Ongeldige queryparameter waarde bij zoeken
     | maxLength    | Waarde is langer dan maximale lengte 4.                      | nummeraanduidingen   | huisnummertoevoeging       | tegenover                   |
     | pattern      | Waarde voldoet niet aan patroon ^[1-9]{1}[0-9]{3}[A-Z]{2}.   | nummeraanduidingen   | postcode                   | 123aa                       |
     | enum         | Waarde heeft geen geldige waarde uit de enumeratie.          | nummeraanduidingen   | geconstateerd              | B                           |
-    | unknownParam | Parameter is niet verwacht.                                  | nummeraanduidingen   | onbekend                   | 0                           |
     | expand       | Deel van de parameterwaarde is niet correct: bestaatniet.    | nummeraanduidingen   | expand                     | bestaatniet                 |
 
   Scenario: geen enkele zoekparameter opgegeven in zoekvraag


### PR DESCRIPTION
Tijdens het implementeren van invalidParams voor de bag-api ontdek ik dat een parameter validatie ontbreekt. Deze is toegevoegd aan de feature file:
- Een timestamp validatie is van toepassing op de `beschikbaarOp` parameter.

Daarnaast zijn 2 validaties verwijderd die niet van toepassing zijn op de bag-api: 
- fields (kennen we niet binnen de bag-api)
- unknownParam (de bag-api is niet strikt, onbekende parameters worden genegeerd)