### PR TITLE
Known issue opgelost.

### DIFF
--- a/Releasenotes/Releasenotes.md
+++ b/Releasenotes/Releasenotes.md
@@ -5,9 +5,6 @@
 In deze versie van de LV BAG Individuele Bevragingen API is de volgende functionaliteit geïmplementeerd:
 - Headers voor rate limiting en dagquotum zijn aan de responses toegevoegd.
 
-### Known issues:
-- Als het `/adressen/zoek` of `/adressen?q=` endpoint wordt bevraagd met een pagina die groter is dan het aantal beschikbare pagina's, dan wordt een http 500 geretourneerd.
-
 **Release notes 2.7.0:**  (31 januari 2023)
 --
 


### PR DESCRIPTION
Zoals besproken: het known issue is opgelost maar het api contract is niet aangepast. Daarmee blijft de api versie 2.8.0.
Ik kies ervoor om het known issue te verwijderen bij de huidige api versie.